### PR TITLE
Update golang to 1.20 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-# Alpine docker image to run the go webserver on port 8080
-FROM golang:1.16-alpine
+# Use the official Golang image with Go 1.20 as a base image
+FROM golang:1.20-alpine
 
 # Set the Current Working Directory inside the container
 WORKDIR /app
 
-# Copy go mod and sum files
+# Copy go.mod and go.sum files
 COPY go.mod go.sum ./
 
 # Download all dependencies. Dependencies will be cached if the go.mod and go.sum files are not changed


### PR DESCRIPTION
I got an error when building because the Dockerfile specified golang 1.6, so I updated the version to 1.20 and the proxy works.